### PR TITLE
Add initial Home Assistant SolaX Cloud custom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Home Assistant SolaX Cloud Integration
+
+A custom [Home Assistant](https://www.home-assistant.io/) integration that adds support for monitoring your SolaX inverter through the official SolaX Cloud API. Installable through [HACS](https://hacs.xyz/).
+
+## Features
+
+- Simple configuration via the Home Assistant UI (config flow)
+- Polls the SolaX Cloud API every 5 minutes
+- Exposes common inverter metrics such as AC power, energy production, consumption and battery information
+- Designed to work entirely through the cloud API (no local network connection required)
+
+## Installation
+
+1. Ensure [HACS](https://hacs.xyz/) is installed in your Home Assistant instance.
+2. Add this repository as a custom repository in HACS (category: Integration).
+3. Install the **SolaX Cloud** integration from HACS and restart Home Assistant if prompted.
+4. In Home Assistant, go to **Settings → Devices & Services** and add the **SolaX Cloud** integration.
+
+## Configuration
+
+During configuration you will be asked for:
+
+- **Token ID** – available from the SolaX Cloud portal under *User Center → API Management*.
+- **Inverter serial number** – the serial number of the inverter registered in SolaX Cloud.
+
+Both pieces of information are required by the SolaX Cloud API, as documented by SolaX. The integration validates the credentials before creating the entry.
+
+## Disclaimer
+
+This project is not affiliated with or endorsed by SolaX. Use at your own risk.

--- a/custom_components/solax_cloud/__init__.py
+++ b/custom_components/solax_cloud/__init__.py
@@ -1,0 +1,79 @@
+"""The SolaX Cloud integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from aiohttp import ClientSession
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import (
+    SolaxCloudApiClient,
+    SolaxCloudApiError,
+    SolaxCloudAuthenticationError,
+    SolaxCloudRequestData,
+)
+from .const import (
+    CONF_SERIAL_NUMBER,
+    CONF_TOKEN_ID,
+    COORDINATOR_UPDATE_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    PLATFORMS,
+)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up SolaX Cloud via YAML (not supported)."""
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up SolaX Cloud from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    session: ClientSession = async_get_clientsession(hass)
+    request_data = SolaxCloudRequestData(
+        token_id=entry.data[CONF_TOKEN_ID],
+        serial_number=entry.data[CONF_SERIAL_NUMBER],
+    )
+    api = SolaxCloudApiClient(session, request_data)
+
+    async def async_update_data() -> dict:
+        try:
+            return await api.async_get_data()
+        except SolaxCloudAuthenticationError as err:
+            raise UpdateFailed("Authentication failed while updating SolaX Cloud data") from err
+        except SolaxCloudApiError as err:
+            raise UpdateFailed(str(err)) from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name="solax_cloud",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=COORDINATOR_UPDATE_INTERVAL),
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/solax_cloud/api.py
+++ b/custom_components/solax_cloud/api.py
@@ -1,0 +1,67 @@
+"""API client for the SolaX Cloud integration."""
+
+from __future__ import annotations
+
+from asyncio import TimeoutError as AsyncioTimeoutError
+from dataclasses import dataclass
+
+from aiohttp import ClientError, ClientSession
+
+from .const import API_BASE_URL, CONF_SERIAL_NUMBER, CONF_TOKEN_ID, EXCEPTION_KEY, LOGGER, RESULT_KEY, SUCCESS_KEY
+
+
+class SolaxCloudApiError(RuntimeError):
+    """Raised when the SolaX Cloud API returns an error."""
+
+
+class SolaxCloudAuthenticationError(SolaxCloudApiError):
+    """Raised when authentication with the SolaX Cloud API fails."""
+
+
+@dataclass(slots=True)
+class SolaxCloudRequestData:
+    """Data required to query the SolaX Cloud API."""
+
+    token_id: str
+    serial_number: str
+
+
+class SolaxCloudApiClient:
+    """Minimal SolaX Cloud API client."""
+
+    def __init__(self, session: ClientSession, data: SolaxCloudRequestData) -> None:
+        self._session = session
+        self._data = data
+
+    async def async_get_data(self) -> dict:
+        """Return the latest data from the cloud API."""
+
+        params = {
+            CONF_TOKEN_ID: self._data.token_id,
+            "sn": self._data.serial_number,
+        }
+
+        LOGGER.debug("Requesting SolaX Cloud data", extra={"params": params})
+
+        try:
+            async with self._session.get(API_BASE_URL, params=params, timeout=30) as response:
+                response.raise_for_status()
+                payload: dict = await response.json(content_type=None)
+        except ClientError as err:
+            raise SolaxCloudApiError("Could not connect to the SolaX Cloud API") from err
+        except AsyncioTimeoutError as err:
+            raise SolaxCloudApiError("Timeout while communicating with the SolaX Cloud API") from err
+
+        LOGGER.debug("Received SolaX Cloud payload", extra={"payload": payload})
+
+        if not payload.get(SUCCESS_KEY, False):
+            message = payload.get(EXCEPTION_KEY) or "Unknown error"
+            # Invalid token/serial number combinations use a specific exception string
+            if "not match" in message.lower() or "tokenid" in message.lower():
+                raise SolaxCloudAuthenticationError(message)
+            raise SolaxCloudApiError(message)
+
+        if RESULT_KEY not in payload or not isinstance(payload[RESULT_KEY], dict):
+            raise SolaxCloudApiError("Unexpected API payload received")
+
+        return payload[RESULT_KEY]

--- a/custom_components/solax_cloud/config_flow.py
+++ b/custom_components/solax_cloud/config_flow.py
@@ -1,0 +1,71 @@
+"""Config flow for the SolaX Cloud integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import (
+    SolaxCloudApiClient,
+    SolaxCloudApiError,
+    SolaxCloudAuthenticationError,
+    SolaxCloudRequestData,
+)
+from .const import CONF_SERIAL_NUMBER, CONF_TOKEN_ID, DOMAIN
+
+
+class SolaxCloudConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SolaX Cloud."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
+        """Handle the initial step."""
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            user_input = {
+                CONF_TOKEN_ID: user_input[CONF_TOKEN_ID].strip(),
+                CONF_SERIAL_NUMBER: user_input[CONF_SERIAL_NUMBER].strip().upper(),
+            }
+
+            await self.async_set_unique_id(user_input[CONF_SERIAL_NUMBER])
+            self._abort_if_unique_id_configured()
+
+            session = async_get_clientsession(self.hass)
+            request_data = SolaxCloudRequestData(
+                token_id=user_input[CONF_TOKEN_ID],
+                serial_number=user_input[CONF_SERIAL_NUMBER],
+            )
+            api = SolaxCloudApiClient(session, request_data)
+
+            try:
+                result = await api.async_get_data()
+            except SolaxCloudAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except SolaxCloudApiError:
+                errors["base"] = "cannot_connect"
+            else:
+                # Store some metadata for device info purposes
+                return self.async_create_entry(
+                    title=result.get("inverterSN") or user_input[CONF_SERIAL_NUMBER],
+                    data=user_input,
+                )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_TOKEN_ID): str,
+                vol.Required(CONF_SERIAL_NUMBER): str,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_import(self, import_data: dict) -> FlowResult:
+        """Handle import from configuration.yaml."""
+
+        return await self.async_step_user(import_data)

--- a/custom_components/solax_cloud/const.py
+++ b/custom_components/solax_cloud/const.py
@@ -1,0 +1,22 @@
+"""Constants for the SolaX Cloud integration."""
+
+from __future__ import annotations
+
+from logging import Logger, getLogger
+
+DOMAIN = "solax_cloud"
+PLATFORMS: list[str] = ["sensor"]
+
+LOGGER: Logger = getLogger(__package__)
+
+API_BASE_URL = "https://www.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do"
+
+CONF_TOKEN_ID = "token_id"
+CONF_SERIAL_NUMBER = "serial_number"
+DEFAULT_NAME = "SolaX Cloud"
+
+COORDINATOR_UPDATE_INTERVAL = 300  # seconds
+
+RESULT_KEY = "result"
+SUCCESS_KEY = "success"
+EXCEPTION_KEY = "exception"

--- a/custom_components/solax_cloud/manifest.json
+++ b/custom_components/solax_cloud/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "solax_cloud",
+  "name": "SolaX Cloud",
+  "config_flow": true,
+  "documentation": "https://github.com/example/ha_solax_cloud_integration",
+  "iot_class": "cloud_polling",
+  "integration_type": "hub",
+  "codeowners": ["@your-github"],
+  "loggers": ["custom_components.solax_cloud"],
+  "version": "0.1.0"
+}

--- a/custom_components/solax_cloud/sensor.py
+++ b/custom_components/solax_cloud/sensor.py
@@ -1,0 +1,173 @@
+"""Sensor platform for the SolaX Cloud integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_SERIAL_NUMBER, DOMAIN
+
+
+@dataclass(frozen=True)
+class SolaxCloudSensorEntityDescription(SensorEntityDescription):
+    """Describes SolaX Cloud sensor entity."""
+
+    api_keys: tuple[str, ...]
+
+
+SENSOR_DESCRIPTIONS: tuple[SolaxCloudSensorEntityDescription, ...] = (
+    SolaxCloudSensorEntityDescription(
+        key="ac_power",
+        translation_key="ac_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("acpower", "acPower"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="yield_today",
+        translation_key="yield_today",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        api_keys=("yieldtoday", "yieldToday"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="yield_total",
+        translation_key="yield_total",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        api_keys=("yieldtotal", "yieldTotal"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="feed_in_power",
+        translation_key="feed_in_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("feedinpower", "feedInPower"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="feed_in_energy",
+        translation_key="feed_in_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        api_keys=("feedinenergy", "feedInEnergy"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="consume_energy",
+        translation_key="consume_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        api_keys=("consumeenergy", "consumeEnergy"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="consume_energy_today",
+        translation_key="consume_energy_today",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        api_keys=("consumeenergy_today", "consumeEnergyToday"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="battery_power",
+        translation_key="battery_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("bat_power", "batPower", "battery_power"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="soc",
+        translation_key="state_of_charge",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("soc", "batterySoc"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="ac_frequency",
+        translation_key="ac_frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        native_unit_of_measurement="Hz",
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("acfre", "acFre"),
+    ),
+    SolaxCloudSensorEntityDescription(
+        key="temperature",
+        translation_key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        api_keys=("tempperature", "temperature"),
+    ),
+)
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up SolaX Cloud sensors based on a config entry."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    serial_number: str = entry.data[CONF_SERIAL_NUMBER]
+
+    async_add_entities(
+        SolaxCloudSensor(coordinator, entry, description, serial_number)
+        for description in SENSOR_DESCRIPTIONS
+        if any(key in coordinator.data for key in description.api_keys)
+    )
+
+
+class SolaxCloudSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a SolaX Cloud sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        entry: ConfigEntry,
+        description: SolaxCloudSensorEntityDescription,
+        serial_number: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial_number)},
+            name="SolaX Inverter",
+            manufacturer="SolaX",
+        )
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+
+        value = None
+        for key in self.entity_description.api_keys:
+            if key in self.coordinator.data:
+                value = self.coordinator.data[key]
+                break
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return value
+        return value

--- a/custom_components/solax_cloud/translations/en.json
+++ b/custom_components/solax_cloud/translations/en.json
@@ -1,0 +1,58 @@
+{
+  "config": {
+    "flow_title": "{serial_number}",
+    "step": {
+      "user": {
+        "title": "Connect to SolaX Cloud",
+        "description": "Enter the token ID and inverter serial number from the SolaX Cloud portal.",
+        "data": {
+          "token_id": "Token ID",
+          "serial_number": "Inverter serial number"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Der Token oder die Seriennummer sind ungültig.",
+      "cannot_connect": "Verbindung zur SolaX Cloud API fehlgeschlagen."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "solax_cloud": {
+        "ac_power": {
+          "name": "AC-Leistung"
+        },
+        "yield_today": {
+          "name": "Ertrag heute"
+        },
+        "yield_total": {
+          "name": "Gesamtertrag"
+        },
+        "feed_in_power": {
+          "name": "Einspeiseleistung"
+        },
+        "feed_in_energy": {
+          "name": "Eingespeiste Energie"
+        },
+        "consume_energy": {
+          "name": "Verbrauchte Energie"
+        },
+        "consume_energy_today": {
+          "name": "Verbrauch heute"
+        },
+        "battery_power": {
+          "name": "Batterieleistung"
+        },
+        "state_of_charge": {
+          "name": "Batterieladung"
+        },
+        "ac_frequency": {
+          "name": "Netzfrequenz"
+        },
+        "temperature": {
+          "name": "Invertertemperatur"
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "SolaX Cloud Integration",
+  "content_in_root": false,
+  "render_readme": true,
+  "filename": "custom_components/solax_cloud/manifest.json"
+}


### PR DESCRIPTION
## Summary
- add a Home Assistant custom integration for SolaX Cloud with config flow support
- implement a cloud API client, coordinator-based data update flow, and sensors for common inverter metrics
- document installation steps and provide HACS metadata for distribution

## Testing
- python -m compileall custom_components

------
https://chatgpt.com/codex/tasks/task_e_68d65ac6b4cc8327a957014f44baf80d