### PR TITLE
feat: expose textual SolaX Cloud metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install homeassistant
+      - name: Run hassfest
+        run: python3 -m script.hassfest
+
+  hacs:
+    name: HACS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS Validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+      - name: Run pytest
+        run: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.2.0 - 2024-05-01
+- Added automatic exposure of all numeric metrics provided by the SolaX Cloud API.
+- Added support for textual status fields alongside numeric metrics.
+- Improved device handling so that all entities are attached to the inverter device with richer metadata.
+- Added Home Assistant validation workflows (hassfest and HACS) and initial test scaffolding.
+- Updated translations for new solar metrics.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration that adds 
 
 - Simple configuration via the Home Assistant UI (config flow)
 - Polls the SolaX Cloud API every 5 minutes
-- Exposes all numeric metrics provided by the SolaX Cloud API, including detailed PV, grid and battery statistics
+- Exposes the full set of metrics provided by the SolaX Cloud API, including detailed PV, grid, battery and status statistics
 - Designed to work entirely through the cloud API (no local network connection required)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A custom [Home Assistant](https://www.home-assistant.io/) integration that adds 
 
 - Simple configuration via the Home Assistant UI (config flow)
 - Polls the SolaX Cloud API every 5 minutes
-- Exposes common inverter metrics such as AC power, energy production, consumption and battery information
+- Exposes all numeric metrics provided by the SolaX Cloud API, including detailed PV, grid and battery statistics
 - Designed to work entirely through the cloud API (no local network connection required)
 
 ## Installation
@@ -28,3 +28,7 @@ Both pieces of information are required by the SolaX Cloud API, as documented by
 ## Disclaimer
 
 This project is not affiliated with or endorsed by SolaX. Use at your own risk.
+
+## Maintainer
+
+- [404GamerNotFound](https://github.com/404GamerNotFound)

--- a/custom_components/solax_cloud/manifest.json
+++ b/custom_components/solax_cloud/manifest.json
@@ -3,6 +3,7 @@
   "name": "SolaX Cloud",
   "config_flow": true,
   "documentation": "https://github.com/404GamerNotFound/ha_solax_cloud_integration",
+  "issue_tracker": "https://github.com/404GamerNotFound/ha_solax_cloud_integration/issues",
   "iot_class": "cloud_polling",
   "integration_type": "hub",
   "codeowners": ["@404GamerNotFound"],

--- a/custom_components/solax_cloud/manifest.json
+++ b/custom_components/solax_cloud/manifest.json
@@ -2,10 +2,10 @@
   "domain": "solax_cloud",
   "name": "SolaX Cloud",
   "config_flow": true,
-  "documentation": "https://github.com/example/ha_solax_cloud_integration",
+  "documentation": "https://github.com/404GamerNotFound/ha_solax_cloud_integration",
   "iot_class": "cloud_polling",
   "integration_type": "hub",
-  "codeowners": ["@your-github"],
+  "codeowners": ["@404GamerNotFound"],
   "loggers": ["custom_components.solax_cloud"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/solax_cloud/sensor.py
+++ b/custom_components/solax_cloud/sensor.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
+import re
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -12,6 +15,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
@@ -21,6 +27,24 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_SERIAL_NUMBER, DOMAIN
+
+
+DEVICE_METADATA_KEYS = {
+    "plantname",
+    "plant_name",
+    "plantid",
+    "plant_id",
+    "timezone",
+    "time_zone",
+    "invertertype",
+    "inverter_type",
+    "type",
+    "fwversion",
+    "fw_version",
+    "firmware",
+    "serialnumber",
+    "serial_number",
+}
 
 
 @dataclass(frozen=True)
@@ -99,7 +123,7 @@ SENSOR_DESCRIPTIONS: tuple[SolaxCloudSensorEntityDescription, ...] = (
         key="soc",
         translation_key="state_of_charge",
         device_class=SensorDeviceClass.BATTERY,
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         api_keys=("soc", "batterySoc"),
     ),
@@ -109,7 +133,7 @@ SENSOR_DESCRIPTIONS: tuple[SolaxCloudSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.FREQUENCY,
         native_unit_of_measurement="Hz",
         state_class=SensorStateClass.MEASUREMENT,
-        api_keys=("acfre", "acFre"),
+        api_keys=("acfre", "acFre", "acFrequency"),
     ),
     SolaxCloudSensorEntityDescription(
         key="temperature",
@@ -120,6 +144,210 @@ SENSOR_DESCRIPTIONS: tuple[SolaxCloudSensorEntityDescription, ...] = (
         api_keys=("tempperature", "temperature"),
     ),
 )
+
+
+_SLUG_RE = re.compile(r"[^0-9a-z]+")
+
+
+def _slugify(value: str) -> str:
+    """Return a slugified version of an API key."""
+
+    if not value:
+        return ""
+
+    camel_to_snake = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    camel_to_snake = re.sub(r"([A-Za-z])(\d)", r"\1_\2", camel_to_snake)
+    camel_to_snake = re.sub(r"(\d)([A-Za-z])", r"\1_\2", camel_to_snake)
+    for token in ("power", "energy", "voltage", "current", "temperature", "frequency", "capacity"):
+        camel_to_snake = re.sub(
+            rf"(?i)(?<=[a-z0-9])({token})",
+            lambda match: f"_{match.group(1).lower()}",
+            camel_to_snake,
+        )
+    slug = _SLUG_RE.sub("_", camel_to_snake.lower()).strip("_")
+    return slug
+
+
+def _title_from_slug(slug: str) -> str:
+    """Return a human readable name from a slug."""
+
+    return slug.replace("_", " ").replace("  ", " ").strip().title()
+
+
+def _is_numeric(value: Any) -> bool:
+    """Return True if the value can be interpreted as a number."""
+
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return False
+        try:
+            float(value)
+        except ValueError:
+            return False
+        return True
+    return False
+
+
+def _expand_key_variants(key: str) -> tuple[str, ...]:
+    """Return a set of likely API key variations."""
+
+    if not key:
+        return tuple()
+    slug = _slugify(key)
+    if not slug:
+        return (key,)
+    parts = slug.split("_")
+    camel = parts[0] + "".join(word.capitalize() for word in parts[1:])
+    pascal = "".join(word.capitalize() for word in parts)
+    variants = {key, slug.replace("_", ""), slug, camel, pascal, key.lower()}
+    return tuple(variant for variant in variants if variant)
+
+
+def _resolve_data_key(data: dict[str, Any], candidates: Iterable[str]) -> str | None:
+    """Resolve the actual key from the API data for the provided candidates."""
+
+    if not candidates:
+        return None
+
+    lowercase_map = {existing_key.lower(): existing_key for existing_key in data}
+    for candidate in candidates:
+        if candidate in data:
+            return candidate
+        candidate_lower = candidate.lower()
+        if candidate_lower in lowercase_map:
+            return lowercase_map[candidate_lower]
+    return None
+
+
+def _derive_units(
+    key: str, value: Any
+) -> tuple[SensorDeviceClass | None, str | None, SensorStateClass | None]:
+    """Derive sensible defaults for units and device classes based on the key."""
+
+    if not _is_numeric(value):
+        return (None, None, None)
+
+    lowered = key.lower()
+    if any(token in lowered for token in ("yield", "energy", "generation")):
+        return (
+            SensorDeviceClass.ENERGY,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            SensorStateClass.TOTAL_INCREASING,
+        )
+    if "power" in lowered:
+        return (
+            SensorDeviceClass.POWER,
+            UnitOfPower.WATT,
+            SensorStateClass.MEASUREMENT,
+        )
+    if "current" in lowered or lowered.endswith("_a"):
+        return (
+            SensorDeviceClass.CURRENT,
+            UnitOfElectricCurrent.AMPERE,
+            SensorStateClass.MEASUREMENT,
+        )
+    if "voltage" in lowered or lowered.endswith("_v") or "_volt" in lowered:
+        return (
+            SensorDeviceClass.VOLTAGE,
+            UnitOfElectricPotential.VOLT,
+            SensorStateClass.MEASUREMENT,
+        )
+    if any(token in lowered for token in ("temperature", "temp")):
+        return (
+            SensorDeviceClass.TEMPERATURE,
+            UnitOfTemperature.CELSIUS,
+            SensorStateClass.MEASUREMENT,
+        )
+    if any(token in lowered for token in ("frequency", "freq", "hz")):
+        return (
+            SensorDeviceClass.FREQUENCY,
+            "Hz",
+            SensorStateClass.MEASUREMENT,
+        )
+    if "soc" in lowered or "soh" in lowered or "percent" in lowered:
+        return (SensorDeviceClass.BATTERY, PERCENTAGE, SensorStateClass.MEASUREMENT)
+    if "efficiency" in lowered:
+        return (None, PERCENTAGE, SensorStateClass.MEASUREMENT)
+    if "capacity" in lowered:
+        return (None, UnitOfEnergy.KILO_WATT_HOUR, SensorStateClass.MEASUREMENT)
+    return (None, None, SensorStateClass.MEASUREMENT)
+
+
+def _build_device_info(entry: ConfigEntry, data: dict[str, Any], serial_number: str) -> DeviceInfo:
+    """Return the device information for the integration."""
+
+    suggested_name = entry.title or data.get("plantname") or data.get("plantName")
+    if not suggested_name:
+        suggested_name = "SolaX Inverter"
+
+    model = data.get("invertertype") or data.get("inverterType") or data.get("type")
+    sw_version = data.get("fwversion") or data.get("firmware") or data.get("fwVersion")
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, serial_number)},
+        manufacturer="SolaX",
+        name=suggested_name,
+        model=model,
+        sw_version=sw_version,
+    )
+
+
+def _iter_dynamic_descriptions(
+    data: dict[str, Any],
+    existing_slugs: set[str],
+    used_data_keys: set[str],
+) -> Iterable[tuple[SolaxCloudSensorEntityDescription, str]]:
+    """Yield entity descriptions for all supported API fields."""
+
+    seen_slugs = set(existing_slugs)
+
+    for raw_key, value in data.items():
+        if raw_key is None:
+            continue
+
+        lower_key = raw_key.lower()
+
+        if lower_key in used_data_keys or lower_key in DEVICE_METADATA_KEYS:
+            continue
+
+        if value is None:
+            continue
+
+        if isinstance(value, str) and not value.strip():
+            continue
+
+        slug = _slugify(raw_key)
+        if not slug or slug in seen_slugs:
+            # Avoid duplicates or invalid slugs
+            if slug in seen_slugs:
+                base_slug = slug
+                counter = 2
+                while f"{base_slug}_{counter}" in seen_slugs:
+                    counter += 1
+                slug = f"{base_slug}_{counter}"
+            else:
+                continue
+
+        seen_slugs.add(slug)
+
+        name = _title_from_slug(slug)
+        device_class, unit, state_class = _derive_units(slug, value)
+        description = SolaxCloudSensorEntityDescription(
+            key=slug,
+            name=name,
+            device_class=device_class,
+            native_unit_of_measurement=unit,
+            state_class=state_class,
+            api_keys=_expand_key_variants(raw_key),
+        )
+        yield description, raw_key
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
@@ -127,12 +355,46 @@ async def async_setup_entry(
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
     serial_number: str = entry.data[CONF_SERIAL_NUMBER]
+    device_info = _build_device_info(entry, coordinator.data, serial_number)
 
-    async_add_entities(
-        SolaxCloudSensor(coordinator, entry, description, serial_number)
-        for description in SENSOR_DESCRIPTIONS
-        if any(key in coordinator.data for key in description.api_keys)
-    )
+    entities: list[SolaxCloudSensor] = []
+    used_slugs: set[str] = set()
+    used_data_keys: set[str] = set()
+
+    for description in SENSOR_DESCRIPTIONS:
+        data_key = _resolve_data_key(coordinator.data, description.api_keys)
+        if not data_key:
+            continue
+        used_slugs.add(description.key)
+        used_data_keys.add(data_key.lower())
+        entities.append(
+            SolaxCloudSensor(
+                coordinator,
+                entry,
+                description,
+                data_key,
+                device_info,
+            )
+        )
+
+    for description, raw_key in _iter_dynamic_descriptions(
+        coordinator.data, used_slugs, used_data_keys
+    ):
+        data_key = _resolve_data_key(coordinator.data, description.api_keys)
+        if not data_key:
+            continue
+        used_data_keys.add(data_key.lower())
+        entities.append(
+            SolaxCloudSensor(
+                coordinator,
+                entry,
+                description,
+                data_key,
+                device_info,
+            )
+        )
+
+    async_add_entities(entities)
 
 
 class SolaxCloudSensor(CoordinatorEntity, SensorEntity):
@@ -145,26 +407,20 @@ class SolaxCloudSensor(CoordinatorEntity, SensorEntity):
         coordinator,
         entry: ConfigEntry,
         description: SolaxCloudSensorEntityDescription,
-        serial_number: str,
+        data_key: str,
+        device_info: DeviceInfo,
     ) -> None:
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{entry.entry_id}-{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, serial_number)},
-            name="SolaX Inverter",
-            manufacturer="SolaX",
-        )
+        self._attr_device_info = device_info
+        self._data_key = data_key
 
     @property
     def native_value(self):
         """Return the state of the sensor."""
 
-        value = None
-        for key in self.entity_description.api_keys:
-            if key in self.coordinator.data:
-                value = self.coordinator.data[key]
-                break
+        value = self.coordinator.data.get(self._data_key)
         if isinstance(value, str):
             try:
                 return float(value)

--- a/custom_components/solax_cloud/translations/en.json
+++ b/custom_components/solax_cloud/translations/en.json
@@ -51,6 +51,39 @@
         },
         "temperature": {
           "name": "Invertertemperatur"
+        },
+        "pv1_power": {
+          "name": "PV1-Leistung"
+        },
+        "pv1_voltage": {
+          "name": "PV1-Spannung"
+        },
+        "pv1_current": {
+          "name": "PV1-Strom"
+        },
+        "pv2_power": {
+          "name": "PV2-Leistung"
+        },
+        "pv2_voltage": {
+          "name": "PV2-Spannung"
+        },
+        "pv2_current": {
+          "name": "PV2-Strom"
+        },
+        "battery_voltage": {
+          "name": "Batteriespannung"
+        },
+        "battery_current": {
+          "name": "Batteriestrom"
+        },
+        "grid_voltage": {
+          "name": "Netzspannung"
+        },
+        "grid_current": {
+          "name": "Netzstrom"
+        },
+        "grid_power": {
+          "name": "Netzleistung"
         }
       }
     }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest>=7.4.0
+pytest-homeassistant-custom-component>=0.13.95

--- a/tests/test_sensor_generation.py
+++ b/tests/test_sensor_generation.py
@@ -1,0 +1,148 @@
+"""Tests for sensor helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
+
+from custom_components.solax_cloud.sensor import (
+    SENSOR_DESCRIPTIONS,
+    _build_device_info,
+    _derive_units,
+    _iter_dynamic_descriptions,
+    _slugify,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        ("acpower", "ac_power"),
+        ("pv1Voltage", "pv1_voltage"),
+        ("pv1Current", "pv1_current"),
+        ("batteryTemperature", "battery_temperature"),
+        ("gridVolt", "grid_volt"),
+        ("", ""),
+    ),
+)
+def test_slugify(value: str, expected: str) -> None:
+    """Ensure slugification produces readable keys."""
+
+    assert _slugify(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("slug", "value", "expected_device_class", "expected_unit", "expected_state_class"),
+    (
+        ("ac_power", 1200, SensorDeviceClass.POWER, UnitOfPower.WATT, SensorStateClass.MEASUREMENT),
+        (
+            "yield_total",
+            32.5,
+            SensorDeviceClass.ENERGY,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            SensorStateClass.TOTAL_INCREASING,
+        ),
+        (
+            "pv1_current",
+            10.2,
+            SensorDeviceClass.CURRENT,
+            UnitOfElectricCurrent.AMPERE,
+            SensorStateClass.MEASUREMENT,
+        ),
+        (
+            "battery_voltage",
+            53.4,
+            SensorDeviceClass.VOLTAGE,
+            UnitOfElectricPotential.VOLT,
+            SensorStateClass.MEASUREMENT,
+        ),
+        (
+            "battery_temperature",
+            25.1,
+            SensorDeviceClass.TEMPERATURE,
+            UnitOfTemperature.CELSIUS,
+            SensorStateClass.MEASUREMENT,
+        ),
+        ("battery_soc", 78, SensorDeviceClass.BATTERY, PERCENTAGE, SensorStateClass.MEASUREMENT),
+        ("efficiency", "90", None, PERCENTAGE, SensorStateClass.MEASUREMENT),
+        ("battery_capacity", 5.8, None, UnitOfEnergy.KILO_WATT_HOUR, SensorStateClass.MEASUREMENT),
+        ("runtime", 12, None, None, SensorStateClass.MEASUREMENT),
+        ("status", "Normal", None, None, None),
+    ),
+)
+def test_derive_units(slug, value, expected_device_class, expected_unit, expected_state_class):
+    """Validate heuristic unit detection."""
+
+    device_class, unit, state_class = _derive_units(slug, value)
+    assert device_class == expected_device_class
+    assert unit == expected_unit
+    assert state_class == expected_state_class
+
+
+def test_dynamic_descriptions_create_for_supported_fields():
+    """All supported fields should result in sensor descriptions."""
+
+    data = {
+        "acpower": 1234,
+        "pv1Voltage": "350.4",
+        "pv1Current": "8.1",
+        "gridpower": 321.1,
+        "status": "Normal",
+        "soc": 67,
+        "batteryTemperature": 29.1,
+        "plantName": "My Plant",
+    }
+    used_slugs = {description.key for description in SENSOR_DESCRIPTIONS}
+    used_data_keys = {"acpower", "soc"}
+
+    dynamic = list(_iter_dynamic_descriptions(data, used_slugs, used_data_keys))
+    generated_keys = {description.key for description, _ in dynamic}
+
+    assert "pv1_voltage" in generated_keys
+    assert "pv1_current" in generated_keys
+    assert "grid_power" in generated_keys
+    assert "battery_temperature" in generated_keys
+    assert "status" in generated_keys
+    # ensure we did not re-create already handled static sensors
+    assert "ac_power" not in generated_keys
+
+
+def test_dynamic_description_for_text_field_has_no_state_class():
+    """Textual dynamic fields should not set a state class."""
+
+    data = {"status": "Normal"}
+    used_slugs = set()
+    used_data_keys = set()
+
+    dynamic = list(_iter_dynamic_descriptions(data, used_slugs, used_data_keys))
+    assert len(dynamic) == 1
+    description, _ = dynamic[0]
+    assert description.key == "status"
+    assert description.state_class is None
+
+
+def test_device_info_uses_entry_and_payload_data():
+    """Device info should include metadata from config entry and payload."""
+
+    entry = MagicMock(spec=ConfigEntry)
+    entry.title = "My inverter"
+    data = {"inverterType": "X1", "fwVersion": "1.2.3"}
+
+    device_info = _build_device_info(entry, data, "1234")
+
+    assert device_info.name == "My inverter"
+    assert device_info.model == "X1"
+    assert device_info.sw_version == "1.2.3"
+    assert ("solax_cloud", "1234") in device_info.identifiers


### PR DESCRIPTION
## Summary
- treat non-numeric SolaX Cloud API fields as entities while filtering device metadata and deriving units from actual values
- expand the helper tests to cover textual metrics and ensure they expose no state class
- refresh the documentation/manifest to credit @404GamerNotFound and record the broader metric coverage

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'homeassistant'; dependencies unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65fa4c9d483278533799a4cb8678f