### PR TITLE
Add EU endpoint fallback for SolaX Cloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,29 @@ During configuration you will be asked for:
 - **Token ID** – available from the SolaX Cloud portal under *User Center → API Management*.
 - **Inverter serial number** – the serial number of the inverter registered in SolaX Cloud.
 
-Both pieces of information are required by the SolaX Cloud API, as documented by SolaX. The integration validates the credentials before creating the entry.
+### Why the serial number is required
+
+The public SolaX Cloud API expects both the API token and the inverter serial number with every request. The serial number tells
+the API which inverter's dataset should be returned for the supplied token. If it is omitted, SolaX simply rejects the request,
+so the integration cannot fall back to token-only authentication. Entering the serial number during the config flow allows Home
+Assistant to store the value once and send it automatically with every poll.
+
+### Troubleshooting connection errors
+
+If you receive the error message **„Verbindung zur SolaX Cloud API fehlgeschlagen“** even though the token and serial number are
+correct, SolaX returned a generic error instead of the dedicated "token/serial does not match" message. In that case:
+
+1. Double-check that the serial number was entered without spaces and matches the value in the SolaX Cloud portal (it is usually
+   printed in upper-case letters).
+2. Ensure the API token has not been regenerated recently. Each time you generate a new token in the portal, the previous token is
+   invalidated.
+3. Verify that the SolaX Cloud service is reachable from your Home Assistant host. Temporary outages or regional endpoints being
+   unavailable also trigger the same error message. The integration automatically tries both the global (`www.solaxcloud.com`)
+   and the European (`euapi.solaxcloud.com`) endpoints, so make sure outbound traffic to both hosts is allowed by your firewall.
+4. Enable debug logging for `custom_components.solax_cloud` to collect the exact response returned by the API when opening an
+   issue.
+
+The integration validates the credentials during configuration and only creates the entry once a successful response is received.
 
 ## Disclaimer
 

--- a/custom_components/solax_cloud/api.py
+++ b/custom_components/solax_cloud/api.py
@@ -7,7 +7,15 @@ from dataclasses import dataclass
 
 from aiohttp import ClientError, ClientSession
 
-from .const import API_BASE_URL, CONF_SERIAL_NUMBER, CONF_TOKEN_ID, EXCEPTION_KEY, LOGGER, RESULT_KEY, SUCCESS_KEY
+from .const import (
+    API_BASE_URLS,
+    CONF_SERIAL_NUMBER,
+    CONF_TOKEN_ID,
+    EXCEPTION_KEY,
+    LOGGER,
+    RESULT_KEY,
+    SUCCESS_KEY,
+)
 
 
 class SolaxCloudApiError(RuntimeError):
@@ -32,19 +40,54 @@ class SolaxCloudApiClient:
     def __init__(self, session: ClientSession, data: SolaxCloudRequestData) -> None:
         self._session = session
         self._data = data
+        self._base_url: str | None = None
 
     async def async_get_data(self) -> dict:
         """Return the latest data from the cloud API."""
+
+        endpoints = (
+            [self._base_url] if self._base_url else []
+        ) + [url for url in API_BASE_URLS if url != self._base_url]
+
+        last_error: SolaxCloudApiError | None = None
+
+        for base_url in endpoints:
+            try:
+                result = await self._async_fetch(base_url)
+            except SolaxCloudAuthenticationError:
+                raise
+            except SolaxCloudApiError as err:
+                last_error = err
+                LOGGER.debug(
+                    "SolaX Cloud request failed", extra={"endpoint": base_url, "error": str(err)}
+                )
+                if base_url == self._base_url:
+                    self._base_url = None
+                continue
+
+            self._base_url = base_url
+            return result
+
+        if last_error is not None:
+            raise last_error
+
+        raise SolaxCloudApiError("Could not connect to the SolaX Cloud API")
+
+    async def _async_fetch(self, base_url: str) -> dict:
+        """Fetch data from a specific endpoint."""
 
         params = {
             CONF_TOKEN_ID: self._data.token_id,
             "sn": self._data.serial_number,
         }
 
-        LOGGER.debug("Requesting SolaX Cloud data", extra={"params": params})
+        LOGGER.debug(
+            "Requesting SolaX Cloud data",
+            extra={"endpoint": base_url, "params": params},
+        )
 
         try:
-            async with self._session.get(API_BASE_URL, params=params, timeout=30) as response:
+            async with self._session.get(base_url, params=params, timeout=30) as response:
                 response.raise_for_status()
                 payload: dict = await response.json(content_type=None)
         except ClientError as err:
@@ -52,7 +95,10 @@ class SolaxCloudApiClient:
         except AsyncioTimeoutError as err:
             raise SolaxCloudApiError("Timeout while communicating with the SolaX Cloud API") from err
 
-        LOGGER.debug("Received SolaX Cloud payload", extra={"payload": payload})
+        LOGGER.debug(
+            "Received SolaX Cloud payload",
+            extra={"endpoint": base_url, "payload": payload},
+        )
 
         if not payload.get(SUCCESS_KEY, False):
             message = payload.get(EXCEPTION_KEY) or "Unknown error"

--- a/custom_components/solax_cloud/const.py
+++ b/custom_components/solax_cloud/const.py
@@ -9,7 +9,10 @@ PLATFORMS: list[str] = ["sensor"]
 
 LOGGER: Logger = getLogger(__package__)
 
-API_BASE_URL = "https://www.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do"
+API_BASE_URLS: tuple[str, ...] = (
+    "https://www.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do",
+    "https://euapi.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do",
+)
 
 CONF_TOKEN_ID = "token_id"
 CONF_SERIAL_NUMBER = "serial_number"


### PR DESCRIPTION
## Summary
- try the global and European SolaX Cloud API endpoints automatically and cache the successful host
- extend debug logging to include the endpoint being used for each request
- document the dual-endpoint behaviour in the troubleshooting guidance

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68d6750185908327aa69839bbf97e4d6