### PR TITLE
Fix SolaX Cloud token parameter name

### DIFF
--- a/custom_components/solax_cloud/api.py
+++ b/custom_components/solax_cloud/api.py
@@ -9,8 +9,6 @@ from aiohttp import ClientError, ClientSession
 
 from .const import (
     API_BASE_URLS,
-    CONF_SERIAL_NUMBER,
-    CONF_TOKEN_ID,
     EXCEPTION_KEY,
     LOGGER,
     RESULT_KEY,
@@ -77,7 +75,7 @@ class SolaxCloudApiClient:
         """Fetch data from a specific endpoint."""
 
         params = {
-            CONF_TOKEN_ID: self._data.token_id,
+            "tokenId": self._data.token_id,
             "sn": self._data.serial_number,
         }
 


### PR DESCRIPTION
## Summary
- send the SolaX Cloud token as `tokenId` so the cloud API accepts the request

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68d76fed538c8327b0b0aa42086cf2c2