### PR TITLE
Expand SolaX endpoint fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ correct, SolaX returned a generic error instead of the dedicated "token/serial d
 2. Ensure the API token has not been regenerated recently. Each time you generate a new token in the portal, the previous token is
    invalidated.
 3. Verify that the SolaX Cloud service is reachable from your Home Assistant host. Temporary outages or regional endpoints being
-   unavailable also trigger the same error message. The integration automatically tries both the global (`www.solaxcloud.com`)
-   and the European (`euapi.solaxcloud.com`) endpoints, so make sure outbound traffic to both hosts is allowed by your firewall.
+   unavailable also trigger the same error message. The integration automatically tries multiple regional hosts (for example
+   `www.solaxcloud.com`, `api.solaxcloud.com`, `euapi.solaxcloud.com` and `usapi.solaxcloud.com`) and both documented API paths,
+   so make sure outbound traffic to these hosts is allowed by your firewall.
 4. Enable debug logging for `custom_components.solax_cloud` to collect the exact response returned by the API when opening an
    issue.
 

--- a/custom_components/solax_cloud/const.py
+++ b/custom_components/solax_cloud/const.py
@@ -9,9 +9,27 @@ PLATFORMS: list[str] = ["sensor"]
 
 LOGGER: Logger = getLogger(__package__)
 
-API_BASE_URLS: tuple[str, ...] = (
-    "https://www.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do",
-    "https://euapi.solaxcloud.com:9443/proxy/api/getRealtimeInfo.do",
+_API_HOSTS: tuple[str, ...] = (
+    "www.solaxcloud.com",
+    "api.solaxcloud.com",
+    "euapi.solaxcloud.com",
+    "usapi.solaxcloud.com",
+)
+
+_API_PORTS: tuple[str, ...] = (":9443", "")
+
+_API_PATHS: tuple[str, ...] = (
+    "/proxy/api/getRealtimeInfo.do",
+    "/proxyApp/api/getRealtimeInfo.do",
+)
+
+API_BASE_URLS: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        f"https://{host}{port}{path}"
+        for host in _API_HOSTS
+        for port in _API_PORTS
+        for path in _API_PATHS
+    )
 )
 
 CONF_TOKEN_ID = "token_id"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,52 @@
+"""Tests for the SolaX Cloud API client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aiohttp import ClientError
+from pytest import mark
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.solax_cloud.api import SolaxCloudApiClient, SolaxCloudRequestData
+
+
+@mark.asyncio
+async def test_api_client_falls_back_to_alternative_endpoint(monkeypatch) -> None:
+    """Ensure the client retries other endpoints when the first one fails."""
+
+    call_order: list[str] = []
+
+    async def _json(_: Any = None, **__: Any) -> dict[str, Any]:
+        return {"success": True, "result": {"value": 42}}
+
+    response = AsyncMock()
+    response.raise_for_status.return_value = None
+    response.json.side_effect = _json
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = response
+    context_manager.__aexit__.return_value = False
+
+    session = MagicMock()
+
+    def _mock_get(url: str, *args: Any, **kwargs: Any) -> Any:
+        call_order.append(url)
+        if len(call_order) == 1:
+            raise ClientError
+        return context_manager
+
+    session.get.side_effect = _mock_get
+
+    monkeypatch.setattr(
+        "custom_components.solax_cloud.api.API_BASE_URLS",
+        ("https://first", "https://second"),
+        raising=False,
+    )
+
+    client = SolaxCloudApiClient(session, SolaxCloudRequestData("token", "serial"))
+
+    result = await client.async_get_data()
+
+    assert call_order == ["https://first", "https://second"]
+    assert result == {"value": 42}


### PR DESCRIPTION
## Summary
- expand the list of SolaX Cloud endpoints to include additional regions, ports, and API paths
- document the broader endpoint coverage in the troubleshooting section of the README
- add a regression test to ensure the API client falls back to alternative endpoints when necessary

## Testing
- pytest *(fails: missing aiohttp/homeassistant dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d777c33eb48327a5bd2f168655aa84