### PR TITLE
Improve SolaX Cloud config flow error handling

### DIFF
--- a/custom_components/solax_cloud/translations/en.json
+++ b/custom_components/solax_cloud/translations/en.json
@@ -12,8 +12,9 @@
       }
     },
     "error": {
-      "invalid_auth": "Der Token oder die Seriennummer sind ungültig.",
-      "cannot_connect": "Verbindung zur SolaX Cloud API fehlgeschlagen."
+      "invalid_auth": "The token ID or serial number is invalid.",
+      "cannot_connect": "Failed to connect to the SolaX Cloud API.",
+      "api_error": "Failed to connect to the SolaX Cloud API: {error}"
     }
   },
   "entity": {


### PR DESCRIPTION
## Summary
- treat additional SolaX Cloud API error messages as authentication failures
- surface detailed API errors during the config flow and refresh the user-facing strings
- cover the new authentication detection logic with a dedicated unit test

## Testing
- pytest *(fails: missing pytest-homeassistant-custom-component dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7880ef0bc832784a7219e6ea41da1