### PR TITLE
Add detailed error logging for SolaX Cloud integration

### DIFF
--- a/custom_components/solax_cloud/api.py
+++ b/custom_components/solax_cloud/api.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 
 from json import JSONDecodeError
 
-from aiohttp import ClientError, ClientSession, ContentTypeError
-from typing import Final
+from aiohttp import ClientError, ClientResponseError, ClientSession, ContentTypeError
+from typing import Any, Final
 
 from .const import (
     API_BASE_URLS,
@@ -52,6 +52,16 @@ _AUTH_ERROR_MARKERS: Final[tuple[str, ...]] = (
 )
 
 
+def _redact_value(value: str, keep: int = 4) -> str:
+    """Return a redacted representation of sensitive values."""
+
+    if not value:
+        return ""
+    if len(value) <= keep:
+        return "*" * len(value)
+    return f"{'*' * (len(value) - keep)}{value[-keep:]}"
+
+
 class SolaxCloudApiClient:
     """Minimal SolaX Cloud API client."""
 
@@ -59,6 +69,17 @@ class SolaxCloudApiClient:
         self._session = session
         self._data = data
         self._base_url: str | None = None
+        self._log_context: dict[str, Any] = {
+            "token_id": _redact_value(data.token_id),
+            "serial_number": _redact_value(data.serial_number),
+        }
+
+    def _context(self, **extra: Any) -> dict[str, Any]:
+        """Return logging context enriched with integration metadata."""
+
+        context = dict(self._log_context)
+        context.update(extra)
+        return context
 
     async def async_get_data(self) -> dict:
         """Return the latest data from the cloud API."""
@@ -79,6 +100,13 @@ class SolaxCloudApiClient:
                 LOGGER.debug(
                     "SolaX Cloud request failed", extra={"endpoint": base_url, "error": str(err)}
                 )
+                LOGGER.error(
+                    "SolaX Cloud request to %s failed: %s",
+                    base_url,
+                    err,
+                    extra=self._context(endpoint=base_url),
+                    exc_info=err,
+                )
                 if base_url == self._base_url:
                     self._base_url = None
                 continue
@@ -87,6 +115,10 @@ class SolaxCloudApiClient:
             return result
 
         if last_error is not None:
+            LOGGER.error(
+                "SolaX Cloud data update failed after exhausting all endpoints",
+                extra=self._context(error=str(last_error)),
+            )
             raise last_error
 
         raise SolaxCloudApiError("Could not connect to the SolaX Cloud API")
@@ -106,13 +138,43 @@ class SolaxCloudApiClient:
 
         try:
             async with self._session.get(base_url, params=params, timeout=30) as response:
-                response.raise_for_status()
-                payload: dict = await response.json(content_type=None)
-        except (ContentTypeError, JSONDecodeError) as err:
-            raise SolaxCloudApiError("Invalid response received from the SolaX Cloud API") from err
+                try:
+                    response.raise_for_status()
+                except ClientResponseError as err:
+                    LOGGER.error(
+                        "SolaX Cloud API request returned HTTP %s: %s",
+                        err.status,
+                        err.message,
+                        extra=self._context(endpoint=base_url, status=err.status),
+                        exc_info=err,
+                    )
+                    raise SolaxCloudApiError(
+                        "Could not connect to the SolaX Cloud API"
+                    ) from err
+                try:
+                    payload: dict = await response.json(content_type=None)
+                except (ContentTypeError, JSONDecodeError) as err:
+                    LOGGER.error(
+                        "Invalid JSON payload received from the SolaX Cloud API",
+                        extra=self._context(endpoint=base_url, content_type=response.content_type),
+                        exc_info=err,
+                    )
+                    raise SolaxCloudApiError(
+                        "Invalid response received from the SolaX Cloud API"
+                    ) from err
         except ClientError as err:
+            LOGGER.error(
+                "Error communicating with the SolaX Cloud API",
+                extra=self._context(endpoint=base_url),
+                exc_info=err,
+            )
             raise SolaxCloudApiError("Could not connect to the SolaX Cloud API") from err
         except AsyncioTimeoutError as err:
+            LOGGER.error(
+                "Timeout while communicating with the SolaX Cloud API",
+                extra=self._context(endpoint=base_url),
+                exc_info=err,
+            )
             raise SolaxCloudApiError("Timeout while communicating with the SolaX Cloud API") from err
 
         LOGGER.debug(
@@ -126,10 +188,24 @@ class SolaxCloudApiClient:
             if any(token in normalized for token in _AUTH_MESSAGE_CONTEXT) and any(
                 marker in normalized for marker in _AUTH_ERROR_MARKERS
             ):
+                LOGGER.error(
+                    "Authentication with the SolaX Cloud API failed: %s",
+                    message,
+                    extra=self._context(endpoint=base_url),
+                )
                 raise SolaxCloudAuthenticationError(message)
+            LOGGER.error(
+                "SolaX Cloud API returned an error response: %s",
+                message,
+                extra=self._context(endpoint=base_url, raw_payload=payload),
+            )
             raise SolaxCloudApiError(message)
 
         if RESULT_KEY not in payload or not isinstance(payload[RESULT_KEY], dict):
+            LOGGER.error(
+                "Unexpected payload structure received from the SolaX Cloud API",
+                extra=self._context(endpoint=base_url, raw_payload=payload),
+            )
             raise SolaxCloudApiError("Unexpected API payload received")
 
         return payload[RESULT_KEY]


### PR DESCRIPTION
## Summary
- expand the SolaX Cloud API client with contextual error logging and redacted identifiers
- add logging for coordinator updates and config flow failures to highlight the underlying issues

## Testing
- pytest *(fails: missing aiohttp/homeassistant test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d78b8720b88327bd06742184ca3644