### PR TITLE
Allow SolaX Cloud config flow to continue without already_in_progress errors

### DIFF
--- a/custom_components/solax_cloud/config_flow.py
+++ b/custom_components/solax_cloud/config_flow.py
@@ -44,7 +44,9 @@ class SolaxCloudConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SERIAL_NUMBER: user_input[CONF_SERIAL_NUMBER].strip().upper(),
             }
 
-            await self.async_set_unique_id(user_input[CONF_SERIAL_NUMBER])
+            await self.async_set_unique_id(
+                user_input[CONF_SERIAL_NUMBER], raise_on_progress=False
+            )
             self._abort_if_unique_id_configured()
 
             session = async_get_clientsession(self.hass)


### PR DESCRIPTION
## Summary
- avoid aborting the config flow when the same inverter serial number is used while the flow is still in progress by setting the unique ID without raising

## Testing
- pytest *(fails: missing aiohttp/homeassistant test dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b89aef908327a839f980b399047d