### PR TITLE
Improve SolaX Cloud setup reliability

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,32 @@
+"""Tests for the config flow helpers."""
+
+from __future__ import annotations
+
+from custom_components.solax_cloud.config_flow import _classify_api_error
+
+
+def test_classify_api_error_for_unknown_message() -> None:
+    """An unknown API error should map to a connection issue."""
+
+    error, placeholders = _classify_api_error("Unknown error occurred")
+
+    assert error == "cannot_connect"
+    assert placeholders is None
+
+
+def test_classify_api_error_for_blank_message() -> None:
+    """A blank API error should also map to a connection issue."""
+
+    error, placeholders = _classify_api_error("   ")
+
+    assert error == "cannot_connect"
+    assert placeholders is None
+
+
+def test_classify_api_error_for_specific_message() -> None:
+    """Specific API errors should surface their message to the user."""
+
+    error, placeholders = _classify_api_error("Rate limited")
+
+    assert error == "api_error"
+    assert placeholders == {"error": "Rate limited"}


### PR DESCRIPTION
## Summary
- avoid aborting the config flow when the same inverter serial number is used while the flow is still in progress by setting the unique ID without raising
- retry alternative SolaX Cloud endpoints if one responds with a spurious authentication error during setup
- normalize "unknown error" API responses to surface the standard connection error message during setup and cover the helper with unit tests

## Testing
- pytest *(fails: missing aiohttp/homeassistant test dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b89aef908327a839f980b399047d