### PR TITLE
Add SolaX brand to manifest

### DIFF
--- a/custom_components/solax_cloud/manifest.json
+++ b/custom_components/solax_cloud/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/404GamerNotFound/ha_solax_cloud_integration",
   "issue_tracker": "https://github.com/404GamerNotFound/ha_solax_cloud_integration/issues",
+  "brand": "SolaX",
   "iot_class": "cloud_polling",
   "integration_type": "hub",
   "codeowners": ["@404GamerNotFound"],


### PR DESCRIPTION
## Summary
- add the Home Assistant brand identifier for SolaX to the integration manifest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da1f4d597883278d44ddc1cadb91e4