### PR TITLE
Allow configuring custom SolaX Cloud API endpoint

### DIFF
--- a/custom_components/solax_cloud/__init__.py
+++ b/custom_components/solax_cloud/__init__.py
@@ -17,6 +17,7 @@ from .api import (
     SolaxCloudRequestData,
 )
 from .const import (
+    CONF_API_BASE_URL,
     CONF_SERIAL_NUMBER,
     CONF_TOKEN_ID,
     COORDINATOR_UPDATE_INTERVAL,
@@ -51,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     request_data = SolaxCloudRequestData(
         token_id=entry.data[CONF_TOKEN_ID],
         serial_number=entry.data[CONF_SERIAL_NUMBER],
+        api_base_url=entry.data.get(CONF_API_BASE_URL),
     )
     api = SolaxCloudApiClient(session, request_data)
 

--- a/custom_components/solax_cloud/const.py
+++ b/custom_components/solax_cloud/const.py
@@ -9,16 +9,17 @@ PLATFORMS: list[str] = ["sensor"]
 
 LOGGER: Logger = getLogger(__package__)
 
-_API_HOSTS: tuple[str, ...] = (
+API_HOSTS: tuple[str, ...] = (
     "www.solaxcloud.com",
     "api.solaxcloud.com",
     "euapi.solaxcloud.com",
     "usapi.solaxcloud.com",
+    "global.solaxcloud.com",
 )
 
-_API_PORTS: tuple[str, ...] = (":9443", "")
+API_PORTS: tuple[str, ...] = (":9443", "")
 
-_API_PATHS: tuple[str, ...] = (
+API_PATHS: tuple[str, ...] = (
     "/proxy/api/getRealtimeInfo.do",
     "/proxyApp/api/getRealtimeInfo.do",
 )
@@ -26,14 +27,15 @@ _API_PATHS: tuple[str, ...] = (
 API_BASE_URLS: tuple[str, ...] = tuple(
     dict.fromkeys(
         f"https://{host}{port}{path}"
-        for host in _API_HOSTS
-        for port in _API_PORTS
-        for path in _API_PATHS
+        for host in API_HOSTS
+        for port in API_PORTS
+        for path in API_PATHS
     )
 )
 
 CONF_TOKEN_ID = "token_id"
 CONF_SERIAL_NUMBER = "serial_number"
+CONF_API_BASE_URL = "api_base_url"
 DEFAULT_NAME = "SolaX Cloud"
 
 COORDINATOR_UPDATE_INTERVAL = 300  # seconds

--- a/custom_components/solax_cloud/translations/en.json
+++ b/custom_components/solax_cloud/translations/en.json
@@ -4,10 +4,11 @@
     "step": {
       "user": {
         "title": "Connect to SolaX Cloud",
-        "description": "Enter the token ID and inverter serial number from the SolaX Cloud portal.",
+        "description": "Enter the token ID, inverter serial number and API base URL from the SolaX Cloud portal.",
         "data": {
           "token_id": "Token ID",
-          "serial_number": "Inverter serial number"
+          "serial_number": "Inverter serial number",
+          "api_base_url": "API base URL"
         }
       }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,11 @@ from custom_components.solax_cloud.config_flow import (
     _classify_api_error,
     _normalize_credentials,
 )
-from custom_components.solax_cloud.const import CONF_SERIAL_NUMBER, CONF_TOKEN_ID
+from custom_components.solax_cloud.const import (
+    CONF_API_BASE_URL,
+    CONF_SERIAL_NUMBER,
+    CONF_TOKEN_ID,
+)
 
 
 def test_classify_api_error_for_unknown_message() -> None:
@@ -44,3 +48,11 @@ def test_normalize_credentials_preserves_serial_casing() -> None:
     assert cleaned[CONF_TOKEN_ID] == "Token"
     assert cleaned[CONF_SERIAL_NUMBER] == "abcd1234"
     assert unique_id == "ABCD1234"
+
+
+def test_normalize_credentials_strips_api_base_url() -> None:
+    """The custom API base URL should be stripped of surrounding whitespace."""
+
+    cleaned, _ = _normalize_credentials("token", "serial", "  https://custom  ")
+
+    assert cleaned[CONF_API_BASE_URL] == "https://custom"


### PR DESCRIPTION
## Summary
- require the API base URL alongside the token and serial during the config flow and persist it in the entry
- extend the API client to prioritise the user-supplied endpoint while adding the global Solax host to the fallback list
- refresh translations and tests to cover the new configuration option

## Testing
- pytest *(fails: missing aiohttp/homeassistant dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff14ad12083278d71d8e799b2c28e